### PR TITLE
Update sd-local version from 1.12 to 1.13

### DIFF
--- a/sd-local.rb
+++ b/sd-local.rb
@@ -3,9 +3,9 @@ require "formula"
 class SdLocal < Formula
   desc "sd-local"
   homepage "https://screwdriver.cd/"
-  version "1.0.12"
+  version "1.0.13"
   url "https://github.com/screwdriver-cd/sd-local/releases/download/v#{version}/sd-local_darwin_amd64"
-  sha256 "7f7fbd6564cc68c2f3d286f5293d922a48a8d9a7e80b685c8ae6855a629c80ec"
+  sha256 "412e1b5daaa371612bbb4049714b58682fde858e67154924fbbd0524b5bbb71d"
 
   def install
     bin.install "sd-local_darwin_amd64" => "sd-local"


### PR DESCRIPTION
以下のPRで、sd-local version 1.13がリリースされました。
https://github.com/screwdriver-cd/sd-local/pull/49

sha256は、Releaseのchecksumから確認しました。
https://github.com/screwdriver-cd/sd-local/releases

brew を使用してインストールしているユーザも、1.13が使える様にversionを更新します。

