### PR TITLE
feat: update sd-local to v1.0.18

### DIFF
--- a/sd-local.rb
+++ b/sd-local.rb
@@ -3,9 +3,9 @@ require "formula"
 class SdLocal < Formula
   desc "sd-local"
   homepage "https://screwdriver.cd/"
-  version "1.0.13"
+  version "1.0.18"
   url "https://github.com/screwdriver-cd/sd-local/releases/download/v#{version}/sd-local_darwin_amd64"
-  sha256 "412e1b5daaa371612bbb4049714b58682fde858e67154924fbbd0524b5bbb71d"
+  sha256 "00857c3d48fb66fcbace990da2efccac064b07cc826620347b7f817a4c68d46e"
 
   def install
     bin.install "sd-local_darwin_amd64" => "sd-local"


### PR DESCRIPTION
以下のPRで、sd-local version 1.0.18がリリースされました。
https://github.com/screwdriver-cd/sd-local/pull/54

sha256は、Releaseのchecksumから確認しました。
https://github.com/screwdriver-cd/sd-local/releases

brew を使用してインストールしているユーザも、1.018が使える様にversionを更新します。