### PR TITLE
feat: update sd-local to v1.0.20

### DIFF
--- a/sd-local.rb
+++ b/sd-local.rb
@@ -3,9 +3,9 @@ require "formula"
 class SdLocal < Formula
   desc "sd-local"
   homepage "https://screwdriver.cd/"
-  version "1.0.19"
+  version "1.0.20"
   url "https://github.com/screwdriver-cd/sd-local/releases/download/v#{version}/sd-local_darwin_amd64"
-  sha256 "01b2bec848def67548f93d2fb03f736fb92ef187da03482025c1c0c0f4985159"
+  sha256 "c6953074c2eff62209ed2299a86302277192d38b40d89da945755b6216437731"
 
   def install
     bin.install "sd-local_darwin_amd64" => "sd-local"


### PR DESCRIPTION
sd-local version 1.0.20がリリースされました。

sha256は、Releaseのchecksumから確認しました。
https://github.com/screwdriver-cd/sd-local/releases

brew を使用してインストールしているユーザも、1.020が使える様にversionを更新します。