### PR TITLE
use v1.0.41 as an universal binary

### DIFF
--- a/sd-local.rb
+++ b/sd-local.rb
@@ -1,13 +1,15 @@
-require "formula"
+# frozen_string_literal: true
+
+require 'formula'
 
 class SdLocal < Formula
-  desc "sd-local"
-  homepage "https://screwdriver.cd/"
-  version "1.0.40"
-  url "https://github.com/screwdriver-cd/sd-local/releases/download/v#{version}/sd-local_darwin_amd64"
-  sha256 "ea613eb2bc53871878cffc5f1798091c0ffaeedea876b9e8f67c6be432e784cf"
+  desc 'sd-local'
+  homepage 'https://screwdriver.cd/'
+  version '1.0.41'
+  url "https://github.com/screwdriver-cd/sd-local/releases/download/v#{version}/sd-local_darwin_all"
+  sha256 '3428647d045c93724657009b730a337d99d73b758f3628b29d278c77e43776da'
 
   def install
-    bin.install "sd-local_darwin_amd64" => "sd-local"
+    bin.install 'sd-local_darwin_all' => 'sd-local'
   end
 end


### PR DESCRIPTION
Use `v1.0.41` as an universal binary 
it works with may forked repo.

This PR also do some fixes with a linter. It seems a common format.

```
% brew install sd-local
==> Downloading https://github.com/screwdriver-cd/sd-local/releases/download/v1.0.41/sd-local_darwin_all
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/234148057/d7a5f40b-38bf-4659-9222-5bf3b4f4a513?X-Amz-Algo
######################################################################## 100.0%
==> Installing sd-local from tk3fftk/sd-local
🍺  /opt/homebrew/Cellar/sd-local/1.0.41: 3 files, 21MB, built in 3 seconds
==> `brew cleanup` has not been run in the last 30 days, running now...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /Users/hitakats/Library/Caches/Homebrew/kubernetes-cli--1.23.1... (14.2MB)
Removing: /Users/hitakats/Library/Logs/Homebrew/kubernetes-cli... (64B)

% file $(which sd-local)
/opt/homebrew/bin/sd-local: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
/opt/homebrew/bin/sd-local (for architecture x86_64):   Mach-O 64-bit executable x86_64
/opt/homebrew/bin/sd-local (for architecture arm64):    Mach-O 64-bit executable arm64

% sd-local version
1.0.41
platform: darwin/arm64
go: go1.17.2
compiler: gc
```